### PR TITLE
refactor(controller): Ensure deterministic CR management

### DIFF
--- a/ns.sh
+++ b/ns.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+read -p "Enter the namespace number: " num
+ns_name="test-yellow-ns-$num"
+
+echo "create ns $ns_name"
+kubectl create ns $ns_name
+echo "label ns $ns_name snappcloud.io/team=unknown"
+kubectl label ns $ns_name snappcloud.io/team=unknown --overwrite
+echo "annotate ns $ns_name snappcloud.io/requester="sss""
+kubectl annotate ns $ns_name snappcloud.io/requester="sss" -n $ns_name


### PR DESCRIPTION
### Resolves race conditions and unpredictable behavior by refactoring the
controller to proactively manage NamespaceJanitor CRs for all relevant
namespaces.
### Previously, the controller had conflicting triggers (.For and .Watches)
that could race, causing custom CR configurations to be ignored and
redundant reconciliations to be queued. This was caused by the
controller trying to handle namespaces that might or might not have a
Janitor CR.

### This change implements a new, more robust architecture:
- The controller now ensures a NamespaceJanitor CR with a predictable
  name exists for every relevant namespace, creating a default one if
  it's missing. This eliminates all ambiguity.
- The watch handler is simplified to enqueue requests for this
  predictably named CR.
- Adds checks for the namespace's DeletionTimestamp before creating a
  default CR, fixing errors when reconciling a namespace that is being
  terminated.
- The predicate logic is refined to correctly filter events and avoid
  unnecessary reconciliations for system namespaces.