### PR TITLE
fix/error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,30 +15,24 @@ The Namespace Janitor operator monitors newly created namespaces with `snappclou
 - **14 days after creation**: If still `unknown` and `yellow`, update to `snappcloud.io/flag: red` and send updated notification.
 - **16 days after creation**: If still `unknown` and `red`, delete the namespace and send final notification.
 
-### User Quota Management
-- Limits users to creating a maximum of 3 namespaces with the `unknown` label simultaneously.
-- The quota check occurs during namespace creation.
-
 
 ### Core Components
 
 #### 1. Namespace Controller
 - Watches namespace events.
-- Watches namespace CR
+- Create and watch namespace CRD
 - Manages lifecycle timers using `creationTimestamp` and `RequeueAfter`.
 - Updates namespace labels/annotations for state persistence.
 - Interacts with a message broker for notifications.
 
 #### 2. Validating Admission Webhook
 - Intercepts namespace `CREATE` requests.
-- Enforces the 3-namespace quota per user by querying existing `unknown` namespaces.
-- Admits or denies requests based on quota availability.
 
 #### 3. Namespace Policy CRD
 - Custom Resource Definition (`CRD`) for declarative policy configuration.
 - Fields include:
   - `additionalRecipients` for notification targets.
-  - `deletationTimeExtend` for custom deletion timing.
+  - `deletionTimeExtend` for custom deletion timing.
 
 
 ### Namespace Policy CRD
@@ -55,3 +49,4 @@ spec:
     - "test@example.com"
     - "test2@example.com"
   deletionTimeExtend: 30 # days
+```

--- a/internal/controller/namespacejanitor_controller.go
+++ b/internal/controller/namespacejanitor_controller.go
@@ -49,11 +49,6 @@ const (
 	YellowThreshold = time.Minute * 2 //production >> 7 * 24 * time.Hour
 	RedThreshold    = time.Minute * 4 //production >> 14 * 24 * time.Hour
 	DeleteThreshold = time.Minute * 6 //production >> 16 * 24 * time.Hour
-
-	// Default name for the NamespaceJanitor CR if users create one.
-	// The watch on Namespaces will enqueue a request for a CR with this name
-	// in the namespace that changed.
-	DefaultJanitorCRName = "default-janitor-config"
 )
 
 // EventNotification is a struct that represents a notification event(can be expanded)
@@ -93,20 +88,19 @@ func (r *NamespaceJanitorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	var janitorCR snappcloudv1alpha1.NamespaceJanitor
 	if err := r.Get(ctx, req.NamespacedName, &janitorCR); err != nil {
 		if apierrors.IsNotFound(err) {
-			logger.Info("NamespaceJanitor CR not found. Creating a default one.", "namespace", namespaceName)
 			var nsForCheck corev1.Namespace
 			if err := r.Get(ctx, client.ObjectKey{Name: namespaceName}, &nsForCheck); err != nil {
 				logger.Info("Parent namespace not found while attempting to create default CR. Assuming it was deleted.", "namespace", namespaceName)
-				return ctrl.Result{}, err
+				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
 			if !nsForCheck.ObjectMeta.DeletionTimestamp.IsZero() {
 				logger.Info("Parent namespace is terminating. Skipping creation of default CR.", "namespace", namespaceName)
-				return ctrl.Result{}, nil // Stop. Do not attempt to create anything.
+				return ctrl.Result{}, client.IgnoreNotFound(err)
 
 			}
 			if !isRelevent(&nsForCheck) {
 				logger.Info("Namespace is no longer relevant. Skipping creation of default CR.", "namespace", namespaceName)
-				return ctrl.Result{}, nil
+				return ctrl.Result{}, client.IgnoreNotFound(err)
 			}
 
 			// Create the default CR
@@ -139,7 +133,7 @@ func (r *NamespaceJanitorReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			logger.Info("Target Namespace for this reconciliation cycle not found. It might have been deleted.", "namespace", namespaceName)
 			// If the NamespaceJanitor CR still exist but its Namespace is gone,
 			// we might have to clean up the CR or update its status. For Now, we just stop.
-			return ctrl.Result{}, nil
+			return ctrl.Result{}, client.IgnoreNotFound(err)
 		}
 		logger.Error(err, "failed to get target Namespace", "namespace", namespaceName)
 		return ctrl.Result{}, client.IgnoreNotFound(err)

--- a/internal/controller/namespacejanitor_controller.go
+++ b/internal/controller/namespacejanitor_controller.go
@@ -45,7 +45,9 @@ const (
 	FlagLabelKey           = "snappcloud.io/flag"
 	TeamLabelKey           = "snappcloud.io/team"
 	RequesterAnnotationKey = "snappcloud.io/requester"
+)
 
+var (
 	YellowThreshold = time.Minute * 2 //production >> 7 * 24 * time.Hour
 	RedThreshold    = time.Minute * 4 //production >> 14 * 24 * time.Hour
 	DeleteThreshold = time.Minute * 6 //production >> 16 * 24 * time.Hour

--- a/internal/controller/namespacejanitor_controller_test.go
+++ b/internal/controller/namespacejanitor_controller_test.go
@@ -1,84 +1,281 @@
-/*
-Copyright 2025 mohammadreza.saberi@snapp.cab.
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-*/
-
 package controller
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/types"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	snappcloudv1alpha1 "github.com/rezacloner1372/namespacejanitor.git/api/v1alpha1"
 )
 
 var _ = Describe("NamespaceJanitor Controller", func() {
-	Context("When reconciling a resource", func() {
-		const resourceName = "test-resource"
 
-		ctx := context.Background()
+	// Define constants for the test thresholds to make tests fast.
+	const (
+		testYellowThreshold = 2 * time.Second
+		testRedThreshold    = 4 * time.Second
+		testDeleteThreshold = 6 * time.Second
+	)
 
-		typeNamespacedName := types.NamespacedName{
-			Name:      resourceName,
-			Namespace: "default", // TODO(user):Modify as needed
-		}
-		namespacejanitor := &snappcloudv1alpha1.NamespaceJanitor{}
+	// Override the production constants for the duration of these tests.
+	originalYellowThreshold := YellowThreshold
+	originalRedThreshold := RedThreshold
+	originalDeleteThreshold := DeleteThreshold
+
+	BeforeEach(func() {
+		YellowThreshold = testYellowThreshold
+		RedThreshold = testRedThreshold
+		DeleteThreshold = testDeleteThreshold
+	})
+
+	AfterEach(func() {
+		YellowThreshold = originalYellowThreshold
+		RedThreshold = originalRedThreshold
+		DeleteThreshold = originalDeleteThreshold
+	})
+
+	Context("when a relevant Namespace is created", func() {
+		var (
+			ctx           context.Context
+			testNamespace *corev1.Namespace
+			namespaceName string
+		)
 
 		BeforeEach(func() {
-			By("creating the custom resource for the Kind NamespaceJanitor")
-			err := k8sClient.Get(ctx, typeNamespacedName, namespacejanitor)
-			if err != nil && errors.IsNotFound(err) {
-				resource := &snappcloudv1alpha1.NamespaceJanitor{
-					ObjectMeta: metav1.ObjectMeta{
-						Name:      resourceName,
-						Namespace: "default",
+			ctx = context.Background()
+			namespaceName = "test-ns-for-cr-creation"
+			testNamespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+					Labels: map[string]string{
+						TeamLabelKey: TeamUnknown,
 					},
-					// TODO(user): Specify other spec details if needed.
-				}
-				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
+				},
 			}
+			By("Creating a new Namespace with 'team=unknown' label")
+			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
-			resource := &snappcloudv1alpha1.NamespaceJanitor{}
-			err := k8sClient.Get(ctx, typeNamespacedName, resource)
-			Expect(err).NotTo(HaveOccurred())
-
-			By("Cleanup the specific resource instance NamespaceJanitor")
-			Expect(k8sClient.Delete(ctx, resource)).To(Succeed())
+			By("Cleaning up the test namespace")
+			deletePolicy := metav1.DeletePropagationForeground
+			_ = k8sClient.Delete(ctx, testNamespace, &client.DeleteOptions{
+				PropagationPolicy: &deletePolicy,
+			})
 		})
-		It("should successfully reconcile the resource", func() {
-			By("Reconciling the created resource")
+
+		It("should create a default NamespaceJanitor CR inside it", func() {
 			controllerReconciler := &NamespaceJanitorReconciler{
 				Client: k8sClient,
 				Scheme: k8sClient.Scheme(),
 			}
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      janitorCRName(namespaceName),
+					Namespace: namespaceName,
+				},
+			}
 
-			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
-				NamespacedName: typeNamespacedName,
-			})
+			By("Running the reconciliation loop")
+			result, err := controllerReconciler.Reconcile(ctx, req)
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
+			Expect(result.Requeue).To(BeTrue())
+
+			By("Verifying that the default NamespaceJanitor CR was created")
+			createdCR := &snappcloudv1alpha1.NamespaceJanitor{}
+			crNamespacedName := types.NamespacedName{Name: janitorCRName(namespaceName), Namespace: namespaceName}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, crNamespacedName, createdCR)
+			}, time.Second*5, time.Millisecond*250).Should(Succeed())
+
+			By("Verifying the created CR has an empty spec")
+			Expect(createdCR.Spec.AdditionalRecipients).To(BeEmpty())
+		})
+	})
+
+	Context("when managing the lifecycle of an 'unknown' Namespace", func() {
+		var (
+			ctx                  context.Context
+			controllerReconciler *NamespaceJanitorReconciler
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			controllerReconciler = &NamespaceJanitorReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+		})
+
+		It("should apply the yellow flag when the age exceeds YellowThreshold", func() {
+			namespaceName := "test-ns-yellow"
+			nsKey := types.NamespacedName{Name: namespaceName}
+			testNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   namespaceName,
+					Labels: map[string]string{TeamLabelKey: TeamUnknown},
+				},
+			}
+			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &snappcloudv1alpha1.NamespaceJanitor{
+				ObjectMeta: metav1.ObjectMeta{Name: janitorCRName(namespaceName), Namespace: namespaceName},
+			})).To(Succeed())
+
+			By("Waiting for the YellowThreshold to be exceeded")
+			time.Sleep(testYellowThreshold + time.Millisecond*200)
+
+			By("Reconciling to apply the yellow flag")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: janitorCRName(namespaceName), Namespace: namespaceName}})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the yellow flag is present")
+			Eventually(func(g Gomega) {
+				currentNS := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsKey, currentNS)).To(Succeed())
+				g.Expect(currentNS.Labels).To(HaveKeyWithValue(FlagLabelKey, FlagYellow))
+			}, time.Second*5, time.Millisecond*250).Should(Succeed())
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, testNamespace)).To(Succeed())
+		})
+
+		It("should apply the red flag when the age exceeds RedThreshold", func() {
+			namespaceName := "test-ns-red"
+			nsKey := types.NamespacedName{Name: namespaceName}
+			testNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   namespaceName,
+					Labels: map[string]string{TeamLabelKey: TeamUnknown, FlagLabelKey: FlagYellow},
+				},
+			}
+			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &snappcloudv1alpha1.NamespaceJanitor{
+				ObjectMeta: metav1.ObjectMeta{Name: janitorCRName(namespaceName), Namespace: namespaceName},
+			})).To(Succeed())
+
+			By("Waiting for the RedThreshold to be exceeded")
+			time.Sleep(testRedThreshold + time.Millisecond*200)
+
+			By("Reconciling to apply the red flag")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: janitorCRName(namespaceName), Namespace: namespaceName}})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the red flag is present")
+			Eventually(func(g Gomega) {
+				currentNS := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsKey, currentNS)).To(Succeed())
+				g.Expect(currentNS.Labels).To(HaveKeyWithValue(FlagLabelKey, FlagRed))
+			}, time.Second*5, time.Millisecond*250).Should(Succeed())
+
+			// Cleanup
+			Expect(k8sClient.Delete(ctx, testNamespace)).To(Succeed())
+		})
+
+		It("should delete the namespace when the age exceeds DeleteThreshold", func() {
+			namespaceName := "test-ns-delete"
+			nsKey := types.NamespacedName{Name: namespaceName}
+			testNamespace := &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:   namespaceName,
+					Labels: map[string]string{TeamLabelKey: TeamUnknown, FlagLabelKey: FlagRed},
+				},
+			}
+			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, &snappcloudv1alpha1.NamespaceJanitor{
+				ObjectMeta: metav1.ObjectMeta{Name: janitorCRName(namespaceName), Namespace: namespaceName},
+			})).To(Succeed())
+
+			By("Waiting for the DeleteThreshold to be exceeded")
+			time.Sleep(testDeleteThreshold + time.Millisecond*200)
+
+			By("Reconciling to delete the namespace")
+			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Name: janitorCRName(namespaceName), Namespace: namespaceName}})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the namespace is Terminating")
+			Eventually(func(g Gomega) {
+				terminatingNS := &corev1.Namespace{}
+				g.Expect(k8sClient.Get(ctx, nsKey, terminatingNS)).To(Succeed())
+				g.Expect(terminatingNS.DeletionTimestamp).NotTo(BeNil())
+			}, time.Second*10, time.Millisecond*250).Should(Succeed())
+		})
+	})
+
+	Context("when an 'unknown' namespace is claimed by a team", func() {
+		var (
+			ctx           context.Context
+			testNamespace *corev1.Namespace
+			janitorCR     *snappcloudv1alpha1.NamespaceJanitor
+			namespaceName string
+		)
+
+		BeforeEach(func() {
+			ctx = context.Background()
+			namespaceName = "test-ns-cleanup"
+			testNamespace = &corev1.Namespace{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: namespaceName,
+					Labels: map[string]string{
+						TeamLabelKey: TeamUnknown,
+						FlagLabelKey: FlagYellow,
+					},
+				},
+			}
+			janitorCR = &snappcloudv1alpha1.NamespaceJanitor{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      janitorCRName(namespaceName),
+					Namespace: namespaceName,
+				},
+			}
+			Expect(k8sClient.Create(ctx, testNamespace)).To(Succeed())
+			Expect(k8sClient.Create(ctx, janitorCR)).To(Succeed())
+		})
+
+		AfterEach(func() {
+			_ = k8sClient.Delete(ctx, testNamespace)
+		})
+
+		It("should remove the flag label and update the CR status", func() {
+			controllerReconciler := &NamespaceJanitorReconciler{
+				Client: k8sClient,
+				Scheme: k8sClient.Scheme(),
+			}
+			req := reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: janitorCRName(namespaceName), Namespace: namespaceName},
+			}
+			nsKey := types.NamespacedName{Name: namespaceName}
+			crKey := req.NamespacedName
+
+			By("Simulating the namespace being claimed by a team")
+			currentNS := &corev1.Namespace{}
+			Expect(k8sClient.Get(ctx, nsKey, currentNS)).To(Succeed())
+			currentNS.Labels[TeamLabelKey] = "payments-team"
+			Expect(k8sClient.Update(ctx, currentNS)).To(Succeed())
+
+			By("Reconciling to trigger the cleanup logic")
+			_, err := controllerReconciler.Reconcile(ctx, req)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Verifying the flag label has been removed")
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, nsKey, currentNS)).To(Succeed())
+				g.Expect(currentNS.Labels).ShouldNot(HaveKey(FlagLabelKey))
+			}, time.Second*5, time.Millisecond*250).Should(Succeed())
+
+			By("Verifying the Janitor CR status is updated")
+			updatedCR := &snappcloudv1alpha1.NamespaceJanitor{}
+			Eventually(func(g Gomega) {
+				g.Expect(k8sClient.Get(ctx, crKey, updatedCR)).To(Succeed())
+				g.Expect(updatedCR.Status.Conditions).NotTo(BeEmpty())
+				g.Expect(updatedCR.Status.Conditions[0].Reason).To(Equal("TeamClaimed"))
+			}, time.Second*5, time.Millisecond*250).Should(Succeed())
 		})
 	})
 })

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -72,22 +72,23 @@ var _ = BeforeSuite(func() {
 	}
 
 	var err error
-	// cfg is defined in this file globally.
+	// cfg is defined in this file globally. Downloads local etcd and local kube-apiserver
 	cfg, err = testEnv.Start()
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
-
+	// Install CRDs into the fake API server
 	err = snappcloudv1alpha1.AddToScheme(scheme.Scheme)
 	Expect(err).NotTo(HaveOccurred())
 
 	// +kubebuilder:scaffold:scheme
-
+	// Create a Kubernetes client
 	k8sClient, err = client.New(cfg, client.Options{Scheme: scheme.Scheme})
 	Expect(err).NotTo(HaveOccurred())
 	Expect(k8sClient).NotTo(BeNil())
 
 })
 
+// Shuts down etcd and kube-apiserver
 var _ = AfterSuite(func() {
 	By("tearing down the test environment")
 	cancel()


### PR DESCRIPTION
This change makes controller's error handling more precise and correctly interprets the "disappearance" of a namespace as a successful outcome in the context of deletion, finally stopping the infinite reconciliation loop.